### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            build-tools;34.0.0
+            platforms;android-34
+            platform-tools
+      - name: Build Debug
+        run: |
+          cd Application
+          ./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Android app

## Testing
- `npm run lint` *(fails: semistandard errors)*
- `cd Application && ./gradlew assembleDebug` *(fails: could not resolve io.fabric.tools:gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6846639b8728832a99874400beba7895