### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11 for SDK tools
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            build-tools;34.0.0
+            platforms;android-34
+            platform-tools
+      - name: Set up JDK 8 for build
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Build Debug
+        run: |
+          cd Application
+          ./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Android app
- fix SDK step by using JDK 11 for the Android SDK and JDK 8 for the gradle build

## Testing
- `npm run lint` *(fails: semistandard: not found)*
- `cd Application && ./gradlew assembleDebug` *(fails: Could not determine java version from '21.0.7')*

------
https://chatgpt.com/codex/tasks/task_e_6846639b8728832a99874400beba7895