### PR TITLE
Fix setup-android JDK version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11 for SDK tools
+      - name: Set up JDK 17 for SDK tools
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,8 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          packages: |
-            build-tools;34.0.0
-            platforms;android-34
-            platform-tools
+          packages: 'build-tools;34.0.0 platforms;android-34 platform-tools'
+          log-accepted-android-sdk-licenses: false
       - name: Set up JDK 8 for build
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## Summary
- update `setup-java` step in CI to use JDK17

## Testing
- `npx semistandard Application/LinkBubble/src/main/assets/pagescripts/*` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_68467bc02c94832a8e7ab13a74a7a068