### PR TITLE
Rewrite CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Android CI
 
 on:
   push:
@@ -7,22 +7,12 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Run JS linter
-        run: npx semistandard Application/LinkBubble/src/main/assets/pagescripts/*
-
   build:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17 for SDK tools
+        id: jdk17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -33,6 +23,7 @@ jobs:
           packages: 'build-tools;34.0.0 platforms;android-34 platform-tools'
           log-accepted-android-sdk-licenses: false
       - name: Set up JDK 8 for build
+        id: jdk8
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm ci
-      - run: npm run lint
+      - name: Run JS linter
+        run: npx semistandard Application/LinkBubble/src/main/assets/pagescripts/*
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,43 @@
- name: Android CI
- 
- on:
-   push:
-     branches: [ master ]
-   pull_request:
-     branches: [ master ]
- 
- jobs:
-   build:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v3
-       - name: Set up JDK 17 for SDK tools
-         id: jdk17
-         uses: actions/setup-java@v3
-         with:
-           distribution: 'temurin'
-           java-version: '17'
-       - name: Set up Android SDK
-         uses: android-actions/setup-android@v3
-         with:
-           packages: 'build-tools;34.0.0 platforms;android-34 platform-tools'
-           log-accepted-android-sdk-licenses: false
-       - name: Set up JDK 8 for build
-         id: jdk8
-         uses: actions/setup-java@v3
-         with:
-           distribution: 'temurin'
-           java-version: '8'
-       - name: Build Debug
-         run: |
-           cd Application
-           ./gradlew assembleDebug
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17 for SDK tools
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'build-tools;34.0.0 platforms;android-34 platform-tools'
+          log-accepted-android-sdk-licenses: false
+      - name: Set up JDK 8 for build
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Build Debug
+        run: |
+          cd Application
+          ./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- add dedicated JS lint job
- keep Android build in separate job

## Testing
- `npm run lint` *(fails: semistandard not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68478fd4fa90832a85fcb7d29cc4290e