### PR TITLE
Update docs for JDK 8 requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,5 @@
 - If `npm test` exists, run it as well.
 - Use two-space indentation and semistandard style for JS.
 - Summaries should briefly mention lint and test results.
+- Gradle builds require JDK 8. Ensure `JAVA_HOME` points to JDK 8 or use the
+  `.java-version` file when building the Android project.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm install
 The project requires JDK 8 for Gradle builds. Set your default Java to version 8
 or use the provided `.java-version` file with tools like `jenv`.
 
+Using newer JDK versions can lead to build failures such as a
+`NullPointerException` during Gradle configuration. If you encounter such
+errors, verify that `JAVA_HOME` points to a JDK 8 installation.
+
 ## Update SDK version
 Goto LinkBubble/build.gradle
 


### PR DESCRIPTION
## Summary
- clarify JDK requirement in README
- mention JDK 8 usage in AGENTS guidelines

## Testing
- `npm run lint` *(skipped: no JS changes)*

------
https://chatgpt.com/codex/tasks/task_e_684794db58cc832aa0395a28fc5a056a