### PR TITLE
Update build workflow trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build Artifact
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'build-tools;34.0.0 platforms;android-34 platform-tools'
+          log-accepted-android-sdk-licenses: false
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+      - name: Copy JNI sources
+        run: sh ./scripts/copyJNIFiles.js
+      - name: Prepare project files
+        run: |
+          cp Application/LinkBubble/src/main/AndroidManifest.xml.template Application/LinkBubble/src/main/AndroidManifest.xml
+          cp Application/LinkBubble/src/main/java/com/linkbubble/ConfigAPIs.java.template Application/LinkBubble/src/main/java/com/linkbubble/ConfigAPIs.java
+          echo "sdk.dir=$ANDROID_HOME" > Application/local.properties
+      - name: Run lint
+        run: npm run lint
+      - name: Build Debug
+        run: |
+          cd Application
+          ./gradlew assembleDebug
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: LinkBubble-debug.apk
+          path: Application/LinkBubble/build/outputs/apk/LinkBubble-debug.apk


### PR DESCRIPTION
## Summary
- adjust `build.yml` so artifact builds run only on workflow dispatch

## Testing
- `npm run lint` *(fails: semistandard warnings)*
- `cd Application && ./gradlew assembleDebug --console=plain --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a826ef024832ab88a0714ec131967