### PR TITLE
Fix release workflow deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
           cd Application
           ./gradlew assemblePlaystoreRelease
 
-      - name: Upload APK
-        uses: actions/upload-artifact@v3
-        with:
-          name: LinkBubble-playstore-release.apk
-          path: Application/LinkBubble/build/outputs/apk/LinkBubble-playstore-release.apk
+        - name: Upload APK
+          uses: actions/upload-artifact@v4
+          with:
+            name: LinkBubble-playstore-release.apk
+            path: Application/LinkBubble/build/outputs/apk/LinkBubble-playstore-release.apk
 


### PR DESCRIPTION
## Summary
- update release workflow to use `actions/upload-artifact@v4`

## Testing
- `npx -y semistandard Application/LinkBubble/src/main/assets/pagescripts/*`

------
https://chatgpt.com/codex/tasks/task_e_684a96de3ea8832a89776883661a2ace