### PR TITLE
Fix release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
           cd Application
           ./gradlew assemblePlaystoreRelease
 
-        - name: Upload APK
-          uses: actions/upload-artifact@v4
-          with:
-            name: LinkBubble-playstore-release.apk
-            path: Application/LinkBubble/build/outputs/apk/LinkBubble-playstore-release.apk
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: LinkBubble-playstore-release.apk
+          path: Application/LinkBubble/build/outputs/apk/LinkBubble-playstore-release.apk
 


### PR DESCRIPTION
## Summary
- fix mis-indented step in `release.yml`

## Testing
- `npm install --ignore-scripts`
- `npm run lint` *(fails: semistandard warnings)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68602cd859a8832a9def81f5ff6eaeb1