### PR TITLE
Update docs for Node version check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Use two-space indentation and semistandard style for JS.
 - Summaries should briefly mention lint and test results.
 - Use Node.js 18 (LTS) for builds to ensure compatibility with certain dependencies and avoid native module issues.
-- Verify your Node version with `node --version` before running npm commands.
+- Verify you are using Node.js 18 with `node --version` before running npm commands.
 - Gradle builds require JDK 17. Ensure `JAVA_HOME` points to JDK 17 or use the
   `.java-version` file when building the Android project. The project uses the
   Android Gradle Plugin 8.1.1 with Gradle 8.1.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Use two-space indentation and semistandard style for JS.
 - Summaries should briefly mention lint and test results.
 - Use Node.js 18 (LTS) for builds to ensure compatibility with certain dependencies and avoid native module issues.
+- Verify your Node version with `node --version` before running npm commands.
 - Gradle builds require JDK 17. Ensure `JAVA_HOME` points to JDK 17 or use the
   `.java-version` file when building the Android project. The project uses the
   Android Gradle Plugin 8.1.1 with Gradle 8.1.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Copy `Application/LinkBubble/src/main/AndroidManifest.xml.template` to `Applicat
 npm install  # pulls JNI sources via postinstall
 npm run lint  # enforce semistandard style to ensure code quality and consistency
 
+Run `node --version` to confirm you are using Node.js 18 before running these
+commands. Newer Node versions may cause native module failures.
+
 ### Java Version
 The project requires JDK 17 for Gradle builds. Set your default Java to version 17
 or use the provided `.java-version` file with tools like `jenv`.
@@ -31,6 +34,7 @@ errors, verify that `JAVA_HOME` points to a JDK 17 installation.
 Use Node.js 18 for the project tools. You can install it with `nvm install 18`
 and activate it via `nvm use 18`. Newer versions may introduce compatibility issues with native
 modules.
+Confirm the active version with `node --version` before building or running scripts.
 
 ## Update SDK version
 Goto LinkBubble/build.gradle

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ errors, verify that `JAVA_HOME` points to a JDK 17 installation.
 Use Node.js 18 for the project tools. You can install it with `nvm install 18`
 and activate it via `nvm use 18`. Newer versions may introduce compatibility issues with native
 modules.
-Confirm the active version with `node --version` before building or running scripts.
+Confirm you are using Node.js 18 with `node --version` before building or running scripts.
 
 ## Update SDK version
 Goto LinkBubble/build.gradle


### PR DESCRIPTION
## Summary
- ensure Node 18 requirement is explicit in docs
- remind users to verify Node version before running npm scripts

## Testing
- `npx -y semistandard Application/LinkBubble/src/main/assets/pagescripts/*.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aec4f63b8832aa79143dba4b7394a