### PR TITLE
chore: remove crashlytics and fabric references

### DIFF
--- a/Application/LinkBubble/build.gradle
+++ b/Application/LinkBubble/build.gradle
@@ -36,7 +36,6 @@ def youtubeApiKey = localProperties['YOUTUBE_API_KEY'] ?: ""
 repositories {
     google()
     mavenCentral()
-    maven { url 'https://maven.fabric.io/public' }
 }
 
 def gitSha = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
@@ -136,9 +135,6 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'se.emilsjolander:stickylistheaders:2.1.2'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
-        transitive = true
-    }
     implementation 'com.squareup.retrofit:retrofit:1.5.0'
     implementation 'com.timehop.stickyheadersrecyclerview:library:0.4.0@aar'
     implementation 'com.jakewharton:butterknife:7.0.0'

--- a/Application/LinkBubble/fabric.properties.template
+++ b/Application/LinkBubble/fabric.properties.template
@@ -1,3 +1,0 @@
-#Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public.
-#Mon Aug 03 11:12:30 PDT 2015
-apiSecret=key-here

--- a/Application/LinkBubble/src/main/AndroidManifest.xml
+++ b/Application/LinkBubble/src/main/AndroidManifest.xml
@@ -184,7 +184,6 @@
             </intent-filter>
         </service>
 
-        <meta-data android:name="com.crashlytics.ApiKey" android:value="key-here"/>
 
         <activity
             android:name=".ui.ExpandedActivity"
@@ -283,9 +282,6 @@
 
         -->
 
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="key-here" />
     </application>
 
 </manifest>

--- a/Application/LinkBubble/src/main/AndroidManifest.xml.template
+++ b/Application/LinkBubble/src/main/AndroidManifest.xml.template
@@ -183,7 +183,6 @@
             </intent-filter>
         </service>
 
-        <meta-data android:name="com.crashlytics.ApiKey" android:value="key-here"/>
 
         <activity
             android:name=".ui.ExpandedActivity"
@@ -282,9 +281,6 @@
 
         -->
 
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="key-here" />
     </application>
 
 </manifest>

--- a/Application/LinkBubble/src/main/java/com/linkbubble/MainApplication.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/MainApplication.java
@@ -109,7 +109,7 @@ public class MainApplication extends Application {
         if (Settings.get().isHttpsEverywhereEnabled()) {
             mBus.post(new SettingsMoreActivity.HttpsEverywhereTurnOnEvent());
         }
-        // Enable ad insertion for Crashlytics builds and disable for play store builds
+        // Enable ad insertion for internal builds and disable for play store builds
         ApplicationInfo appInfo = getApplicationInfo();
         if (appInfo.packageName.equals("com.brave.playstore") || appInfo.packageName.equals("com.brave.playstore.dev")) {
             mAdInserterEnabled = true;

--- a/Application/LinkBubble/src/main/java/com/linkbubble/Settings.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/Settings.java
@@ -1004,7 +1004,7 @@ public class Settings {
                 ComponentName componentName = ComponentName.unflattenFromString(flattenedComponentName);
                 if (componentName != null) {
                     for (ResolveInfo resolveInfo : resolveInfos) {
-                        // Handle crash: https://fabric.io/brave6/android/apps/com.linkbubble.playstore/issues/5623e787f5d3a7f76be5b166
+                        // Handle case where resolve info is missing
                         if (resolveInfo == null || resolveInfo.activityInfo == null) {
                             CrashTracking.log("Null resolveInfo when getting default for app: " + resolveInfo);
                             continue;

--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/CanvasView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/CanvasView.java
@@ -331,7 +331,7 @@ public class CanvasView extends FrameLayout {
 
             // The webview can throw an exception when trying to remove focus inside of removeView.
             // To prevent a crash we try to manually unfocus first, within a try/catch to reset ViewGroup::mFocused.
-            // Prevents crash: https://fabric.io/brave6/android/apps/com.linkbubble.playstore/issues/55dccdeee0d514e5d640ab55
+            // Guard against a crash during focus removal
             try {
                 mContentView.clearFocus();
             } catch(Exception e) {

--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
@@ -975,7 +975,7 @@ public class ContentView extends FrameLayout {
                     //boolean isLinkBubblePresent = mAppsForUrl.size() == 1 ? Util.isLinkBubbleResolveInfo(mAppsForUrl.get(0).mResolveInfo) : false;
                     for (AppForUrl info : mAppsForUrl) {
 
-                        // Handle crash: https://fabric.io/brave6/android/apps/com.linkbubble.playstore/issues/562667c7f5d3a7f76bf16a4c
+                        // Handle case where resolve info is missing
                         if (info.mResolveInfo == null || info.mResolveInfo.activityInfo == null) {
                             CrashTracking.log("onPageStarted() Null resolveInfo when getting default for app: " + info);
                             continue;
@@ -2131,7 +2131,7 @@ public class ContentView extends FrameLayout {
 
                         // In certain situations mResolveInfo is null, likely because we can't find the app.
                         // One possibility is that this happens when the app is currently being updated through the play store.
-                        // Prevents crash: https://fabric.io/brave6/android/apps/com.linkbubble.playstore/issues/55dcee53e0d514e5d6413e8d
+                        // Guard against a null resolveInfo
                         if (existing.mResolveInfo == null) {
                             continue;
                         }

--- a/Application/LinkBubble/src/main/java/com/linkbubble/util/CrashTracking.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/util/CrashTracking.java
@@ -6,41 +6,51 @@ package com.linkbubble.util;
 
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
 import com.linkbubble.BuildConfig;
-
-import io.fabric.sdk.android.Fabric;
 
 public class CrashTracking {
 
+    private static final String TAG = "CrashTracking";
+
     public static void logHandledException(Throwable throwable) {
-        Crashlytics.logException(throwable);
+        if (BuildConfig.DEBUG) {
+            Log.e(TAG, "Handled exception", throwable);
+        }
     }
 
     public static void setInt(String key, int value) {
-        Crashlytics.setInt(key, value);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, key + ": " + value);
+        }
     }
 
     public static void setDouble(String key, double value) {
-        Crashlytics.setDouble(key, value);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, key + ": " + value);
+        }
     }
 
     public static void setFloat(String key, float value) {
-        Crashlytics.setFloat(key, value);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, key + ": " + value);
+        }
     }
 
     public static void setString(String key, String string) {
-        Crashlytics.setString(key, string);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, key + ": " + string);
+        }
     }
 
     public static void setBool(String key, boolean value) {
-        Crashlytics.setBool(key, value);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, key + ": " + value);
+        }
     }
 
     public static void log(String message) {
-        Crashlytics.log(message);
         if (BuildConfig.DEBUG) {
-            Log.d("CrashTracking", message);
+            Log.d(TAG, message);
         }
     }
 }

--- a/Application/LinkBubble/src/main/java/com/linkbubble/util/CrashTracking.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/util/CrashTracking.java
@@ -13,14 +13,14 @@ public class CrashTracking {
     private static final String TAG = "CrashTracking";
 
     public static void logHandledException(Throwable throwable) {
-        if (BuildConfig.DEBUG) {
-            Log.e(TAG, "Handled exception", throwable);
-        }
+        Log.e(TAG, "Handled exception", throwable);
     }
 
     private static void logKeyValue(String key, Object value) {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, key + ": " + value);
+        } else {
+            Log.i(TAG, key + ": " + value);
         }
     }
 
@@ -47,6 +47,8 @@ public class CrashTracking {
     public static void log(String message) {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, message);
+        } else {
+            Log.i(TAG, message);
         }
     }
 }

--- a/Application/LinkBubble/src/main/java/com/linkbubble/util/CrashTracking.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/util/CrashTracking.java
@@ -18,34 +18,30 @@ public class CrashTracking {
         }
     }
 
-    public static void setInt(String key, int value) {
+    private static void logKeyValue(String key, Object value) {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, key + ": " + value);
         }
+    }
+
+    public static void setInt(String key, int value) {
+        logKeyValue(key, value);
     }
 
     public static void setDouble(String key, double value) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, key + ": " + value);
-        }
+        logKeyValue(key, value);
     }
 
     public static void setFloat(String key, float value) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, key + ": " + value);
-        }
+        logKeyValue(key, value);
     }
 
     public static void setString(String key, String string) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, key + ": " + string);
-        }
+        logKeyValue(key, string);
     }
 
     public static void setBool(String key, boolean value) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, key + ": " + value);
-        }
+        logKeyValue(key, value);
     }
 
     public static void log(String message) {

--- a/Application/LinkBubble/src/main/java/org/mozilla/gecko/favicons/cache/FaviconsForURL.java
+++ b/Application/LinkBubble/src/main/java/org/mozilla/gecko/favicons/cache/FaviconsForURL.java
@@ -146,7 +146,6 @@ public class FaviconsForURL {
                         mDominantColor = BitmapUtils.getDominantColor(element.mFaviconPayload);
                         return mDominantColor;
                     } catch (IllegalStateException ex) {
-                        // https://crashlytics.com/digital-ashes/android/apps/com.linkbubble.playstore/issues/532b555ffabb27481b16d958
                         CrashTracking.logHandledException(ex);
                     }
                 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ ADB Idea: A useful plugin for working with android apps: https://github.com/pbre
 
 ## Incrementing the patch number
 
-Before each release be sure to increment the versionPatch number within build.gradle. This number should be reset to zero after a minor or major version bump (typically during a release). The patch number is reported to crashlytics and can help pinpoint what commits caused a crash, and to the beta community.
+Before each release be sure to increment the versionPatch number within build.gradle. This number should be reset to zero after a minor or major version bump (typically during a release).

--- a/README.md
+++ b/README.md
@@ -4,12 +4,9 @@
 
 `git clone git@github.com:brave/browser-android.git`
 
-If you wish to enable Crashlytics, copy `Application/LinkBubble/fabric.properties.template` to `Application/LinkBubble/fabric.properties` and fill in the apiSecret.
+Copy `Application/LinkBubble/src/main/java/com/linkbubble/ConfigAPIs.java.template` to `Application/LinkBubble/src/main/java/com/linkbubble/ConfigAPIs.java` and fill in the YouTube apiSecret.
 
-Copy `Application/LinkBubble/src/main/java/com/linkbubble/ConfigAPIs.java.template` to `Application/LinkBubble/src/main/java/com/linkbubble/ConfigAPIs.java` and fill in the youtube apiSecret.
-
-Copy `Application/LinkBubble/src/main/AndroidManifest.xml.template` to `Application/LinkBubble/src/main/AndroidManifest.xml` and, if Crashlytics is used, fill in `com.crashlytics.ApiKey` and
-`io.fabric.ApiKey` with your Crashlytics API key. You can obtain it from logging into your Fabric account and going to: `Settings -> Organizations -> Brave (or your organization)` then click on `API Key` at the top.
+Copy `Application/LinkBubble/src/main/AndroidManifest.xml.template` to `Application/LinkBubble/src/main/AndroidManifest.xml` and update any necessary configuration values.
 
 npm install  # pulls JNI sources via postinstall
 npm run lint  # enforce semistandard style to ensure code quality and consistency

--- a/build_fix_summary.md
+++ b/build_fix_summary.md
@@ -38,7 +38,7 @@
         *   `WebIconDatabase` 是已從 Android SDK 中移除的過時 API。
     *   **解決方案**:
         *   建立一個帶有虛擬值的 `ConfigAPIs.java` 檔案。
-        *   註解掉所有對 `CrashTracking`, `Fabric`, `Analytics` 的呼叫。
+        *   註解掉所有對 `CrashTracking` 與 `Analytics` 的呼叫。
         *   在 `MainService.java` 中加入所有缺少的 `import` 語句。
         *   註解掉對 `WebIconDatabase` 的呼叫。
         *   修正 `NotificationUnhideHandler` 為 `NotificationUnhideActivity` 的打字錯誤。


### PR DESCRIPTION
## Summary
- drop Crashlytics and Fabric dependencies and configuration
- replace CrashTracking with local logging
- clean up documentation and comments referencing Crashlytics

## Testing
- `node --version`
- `npx semistandard Application/LinkBubble/src/main/assets/pagescripts/*` *(fails: lint errors)*
- `npm test` *(fails: Missing script "test")*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4ab9e1b4832a915da4be52852b72